### PR TITLE
Make it easier to use as an embedded library

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -13,6 +13,7 @@ var (
 		ReadTimeout:          3,
 		ReadRetry:            1,
 		ReportForwardTimeout: 1,
+		ReportAllMessages:    false,
 		AESKey:               "",
 	}
 )
@@ -25,6 +26,7 @@ type Configure struct {
 	ReadTimeout          int
 	ReadRetry            int
 	ReportForwardTimeout int
+	ReportAllMessages    bool
 
 	AESKey string
 }
@@ -38,6 +40,7 @@ func NewConfig() *Configure {
 		ReadTimeout:          3,
 		ReadRetry:            1,
 		ReportForwardTimeout: 1,
+		ReportAllMessages:    false,
 		AESKey:               "",
 	}
 }

--- a/device.go
+++ b/device.go
@@ -39,6 +39,14 @@ func (d *Device) GetHeartbeatTimestamp() int64 {
 	return d.heartBeatTimestamp
 }
 
+func (d *Device) shouldPushUpdates() bool {
+	if nil == d.Aqara {
+		return false
+	}
+
+	return d.Aqara.ReportAllMessages
+}
+
 func (d *Device) waitToken() bool {
 	begin := time.Now().Unix()
 	for {

--- a/device.go
+++ b/device.go
@@ -11,6 +11,7 @@ import (
 const (
 	FIELD_STATUS  = "status"
 	FIELD_BATTERY = "battery"
+	FIELD_VOLTAGE = "voltage"
 	FIELD_INUSE   = "inuse"
 	FIELD_TOKEN   = "token"
 )
@@ -153,4 +154,16 @@ func (d *Device) GetDataArray() (array []string) {
 	}
 
 	return
+}
+
+func (d *Device) GetBatteryLevel(current float32) float32 {
+	if d.hasField(FIELD_BATTERY) {
+		return convertToBatteryPercentage(d.GetDataAsUint32(FIELD_BATTERY))
+	}
+
+	if d.hasField(FIELD_VOLTAGE) {
+		return convertToBatteryPercentage(d.GetDataAsUint32(FIELD_VOLTAGE))
+	}
+
+	return current
 }

--- a/dualwiredwallswitch.go
+++ b/dualwiredwallswitch.go
@@ -50,7 +50,7 @@ func (s *DualWiredWallSwitch) Set(dev *Device) {
 		//LOGGER.Warn("%s", status)
 	}
 
-	if change.IsChanged() {
+	if change.IsChanged() || s.shouldPushUpdates() {
 		s.Aqara.StateMessages <- change
 	}
 

--- a/example/contrl_gateway.go
+++ b/example/contrl_gateway.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"time"
+
 	"github.com/bingbaba/tool/color"
 	"github.com/bingbaba/util/logs"
 	"github.com/xuebing1110/migateway"
-	"time"
 )
 
 var (
@@ -16,15 +17,34 @@ func init() {
 }
 
 func main() {
-	manager, err := migateway.NewAqaraManager(nil)
+	manager := migateway.NewAqaraManager()
+	cfg := migateway.NewConfig()
+	cfg.SetAESKey("09F859F7B23A46BE")
+	cfg.ReportAllMessages = true
+	err := manager.Start(cfg)
 	if err != nil {
 		panic(err)
 	}
-	manager.SetAESKey("t7ew6r4y612eml0f")
+
+	time.Sleep(3 * time.Second)
+	manager.Stop()
+	time.Sleep(1 * time.Second)
+
+	manager = migateway.NewAqaraManager()
+	err = manager.Start(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		for msg := range manager.StateMessages {
+			LOGGER.Info("%+v", msg)
+		}
+	}()
 
 	gateway := manager.GateWay
-	for _, color := range color.COLOR_ALL {
-		err = gateway.ChangeColor(color)
+	for _, c := range color.COLOR_ALL {
+		err := gateway.ChangeColor(c)
 		if err != nil {
 			panic(err)
 		}

--- a/gateway.go
+++ b/gateway.go
@@ -71,7 +71,7 @@ func (g *GateWay) Set(dev *Device) {
 	}
 
 	change.To = g.State
-	if change.IsChanged() {
+	if change.IsChanged() || g.shouldPushUpdates() {
 		g.Aqara.StateMessages <- change
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,8 @@
+package migateway
+
+type ILogger interface {
+	Debug(format string, v ...interface{})
+	Info(format string, v ...interface{})
+	Warn(format string, v ...interface{})
+	Error(format string, v ...interface{})
+}

--- a/magnet.go
+++ b/magnet.go
@@ -51,7 +51,7 @@ func (m *Magnet) Set(dev *Device) {
 	}
 
 	change.To = m.State
-	if change.IsChanged() {
+	if change.IsChanged() || m.shouldPushUpdates() {
 		m.Aqara.StateMessages <- change
 	}
 

--- a/magnet.go
+++ b/magnet.go
@@ -2,6 +2,8 @@ package migateway
 
 const (
 	MODEL_MAGNET = "magnet"
+
+	MAGNET_STATUS_OPEN = "open"
 )
 
 type Magnet struct {
@@ -27,7 +29,10 @@ func (m MagnetStateChange) IsChanged() bool {
 func NewMagnet(dev *Device) *Magnet {
 	return &Magnet{
 		Device: dev,
-		State:  MagnetState{Opened: dev.GetDataAsBool(FIELD_STATUS), Battery: 100},
+		State: MagnetState{
+			Opened:  dev.GetDataAsBool(FIELD_STATUS),
+			Battery: dev.GetBatteryLevel(0),
+		},
 	}
 }
 
@@ -39,16 +44,10 @@ func (m *Magnet) Set(dev *Device) {
 	change := &MagnetStateChange{ID: m.Sid, From: m.State, To: m.State}
 	if dev.hasField(FIELD_STATUS) {
 		status := dev.GetData(FIELD_STATUS)
-		if status == "open" {
-			m.State.Opened = true
-		} else {
-			m.State.Opened = false
-		}
+		m.State.Opened = status == MAGNET_STATUS_OPEN
 	}
 
-	if dev.hasField(FIELD_BATTERY) {
-		m.State.Battery = convertToBatteryPercentage(dev.GetDataAsUint32(FIELD_BATTERY))
-	}
+	m.State.Battery = dev.GetBatteryLevel(m.State.Battery)
 
 	change.To = m.State
 	if change.IsChanged() || m.shouldPushUpdates() {

--- a/manager.go
+++ b/manager.go
@@ -196,12 +196,11 @@ func (m *AqaraManager) putDevice(dev *Device) (added bool) {
 		LOGGER.Warn("DEVICESYNC:: unknown model is %s", dev.Model)
 	}
 
-	LOGGER.Debug("save to discovery chan...")
-
 	if nil != discovery {
+		LOGGER.Debug("sending to discovery chan...")
 		m.DiscoveryMessages <- discovery
+		LOGGER.Debug("sending to discovery chan over!")
 	}
-	LOGGER.Debug("save to discovery chan over!")
 
 	return
 }

--- a/motion.go
+++ b/motion.go
@@ -58,7 +58,7 @@ func (m *Motion) Set(dev *Device) {
 		m.State.Battery = float32(voltage) / 33.0
 	}
 	change.To = m.State
-	if change.IsChanged() {
+	if change.IsChanged() || m.shouldPushUpdates() {
 		m.Aqara.StateMessages <- change
 	}
 	if dev.Token != "" {

--- a/plug.go
+++ b/plug.go
@@ -54,7 +54,7 @@ func (p *Plug) Set(dev *Device) {
 		p.State.PowerConsumed = dev.GetDataAsUint32(FIELD_PLUG_POWERCONSUMED)
 	}
 	change.To = p.State
-	if change.IsChanged() {
+	if change.IsChanged() || p.shouldPushUpdates() {
 		p.Aqara.StateMessages <- change
 	}
 	if dev.Token != "" {

--- a/sensor_ht.go
+++ b/sensor_ht.go
@@ -43,7 +43,7 @@ func (s *SensorHT) Set(dev *Device) {
 		s.State.Humidity = dev.GetDataAsFloat64(FIELD_SENSORHT_HUMIDITY) / 100
 	}
 	change.To = s.State
-	if change.IsChanged() {
+	if change.IsChanged() || s.shouldPushUpdates() {
 		s.Aqara.StateMessages <- change
 	}
 	if dev.Token != "" {

--- a/switch.go
+++ b/switch.go
@@ -92,7 +92,7 @@ func (s *Switch) Set(dev *Device) {
 	}
 
 	change.To = s.State
-	if change.IsChanged() {
+	if change.IsChanged() || s.shouldPushUpdates() {
 		s.Aqara.StateMessages <- change
 	}
 


### PR DESCRIPTION
Greetings, 

First of all thank you for your work, this library is great. 

This PR is to allow easier usage of the library from other projects. 
The following changes were made: 

* Stop method for manager
* A new flag `ReportAllMessages`, if set, all updates will be pushed to `StateMessages` even if `obj.IsChanged()` is `false`
* Removed panics from read/write cycles 
* `ILogger` interface which makes easier to overwrite library internal logger
* Fixed and slightly extended the example